### PR TITLE
Add `set` to `AwsCredentialsFile`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@
 //! ## Usage
 //!
 //! ```
+//! use aws_config_mod::{AwsConfigFile, SettingPath, Value};
+//! use std::str::FromStr;
+//! 
 //! // Assuming you already read the configuration file to a string
 //! let config_content = r#"
 //! [profile A]
@@ -35,7 +38,7 @@
 //! ec2 =
 //!   endpoint_url = https://profile-b-ec2-endpoint.aws"#;
 //!
-//! let mut config = AwsConfigFile::parse(SAMPLE_FILE).expect("Sample file should be valid");
+//! let mut config = AwsConfigFile::from_str(config_content).expect("Sample file should be valid");
 //!
 //! let setting_path = SettingPath::try_from("profile.A.credential_source").expect("Should parse");
 //! config.set(setting_path, Value::from("my-new-credential-source"));

--- a/src/model/credentials_file.rs
+++ b/src/model/credentials_file.rs
@@ -3,7 +3,6 @@
 use super::SectionName;
 use super::{header::CredentialHeader, whitespace::Whitespace, Section};
 use crate::lexer::{to_owned_input, Parsable};
-use crate::{Setting, SettingPath, Value};
 use nom::Parser;
 use nom::{combinator::eof, multi::many0, sequence::tuple};
 use std::fmt::Display;

--- a/src/model/credentials_file.rs
+++ b/src/model/credentials_file.rs
@@ -3,7 +3,7 @@
 use super::SectionName;
 use super::{header::CredentialHeader, whitespace::Whitespace, Section};
 use crate::lexer::{to_owned_input, Parsable};
-use crate::{SettingPath, Value};
+use crate::{Setting, SettingPath, Value};
 use nom::Parser;
 use nom::{combinator::eof, multi::many0, sequence::tuple};
 use std::fmt::Display;
@@ -52,33 +52,14 @@ impl AwsCredentialsFile {
             .find(|profile| *profile.get_name() == profile_name)
     }
 
-    // TODO: replace SettingPath with a more generic path
-    /// Provided a [SettingPath] and a [Value], locates the desired [Setting] and changes its [Value].
-    /// If the setting doesn't exist, it will be created. If the [Section] that contains the [Setting]
-    /// doesn't exist, it will also be created.
-    pub fn set(&mut self, setting_path: SettingPath, value: Value) {
-        // If the section type is not a profile, we cannot set it in a credentials file
-        if let Some(section_name) = setting_path.section_path.section_name {
-            let profile = match self.get_profile_mut(section_name.clone()) {
-                Some(section) => section,
-                None => self.insert_profile(section_name),
-            };
-
-            profile.set(setting_path.setting_name, value);
-        } else {
-            // If the section name is None, we cannot set it in a credentials file
-            panic!("Cannot set a setting without a section name in a credentials file");
-        }
-    }
-
     /// Check if the given [Section] exists from a [SectionPath]
     pub(crate) fn contains_profile(&self, profile_name: &SectionName) -> bool {
         self.profiles.iter().any(|section| section.get_name() == profile_name)
     }
 
-    /// Given a [SectionPath], create the [Section] if it doesn't exist and return a mutable
+    /// Given a [SectionName], create the [Section] if it doesn't exist and return a mutable
     /// reference to it.
-    pub(crate) fn insert_profile(
+    pub fn insert_profile(
         &mut self,
         profile_name: SectionName,
     ) -> &mut Section<CredentialHeader> {

--- a/src/model/credentials_file.rs
+++ b/src/model/credentials_file.rs
@@ -3,8 +3,10 @@
 use super::SectionName;
 use super::{header::CredentialHeader, whitespace::Whitespace, Section};
 use crate::lexer::{to_owned_input, Parsable};
+use crate::{SettingPath, Value};
 use nom::Parser;
 use nom::{combinator::eof, multi::many0, sequence::tuple};
+use std::fmt::Display;
 use std::str::FromStr;
 
 /// Represents and aws credentials file. A credentials file contains sensitive authentication information
@@ -48,6 +50,62 @@ impl AwsCredentialsFile {
         self.profiles
             .iter_mut()
             .find(|profile| *profile.get_name() == profile_name)
+    }
+
+    // TODO: replace SettingPath with a more generic path
+    /// Provided a [SettingPath] and a [Value], locates the desired [Setting] and changes its [Value].
+    /// If the setting doesn't exist, it will be created. If the [Section] that contains the [Setting]
+    /// doesn't exist, it will also be created.
+    pub fn set(&mut self, setting_path: SettingPath, value: Value) {
+        // If the section type is not a profile, we cannot set it in a credentials file
+        if let Some(section_name) = setting_path.section_path.section_name {
+            let profile = match self.get_profile_mut(section_name.clone()) {
+                Some(section) => section,
+                None => self.insert_profile(section_name),
+            };
+
+            profile.set(setting_path.setting_name, value);
+        } else {
+            // If the section name is None, we cannot set it in a credentials file
+            panic!("Cannot set a setting without a section name in a credentials file");
+        }
+    }
+
+    /// Check if the given [Section] exists from a [SectionPath]
+    pub(crate) fn contains_profile(&self, profile_name: &SectionName) -> bool {
+        self.profiles.iter().any(|section| section.get_name() == profile_name)
+    }
+
+    /// Given a [SectionPath], create the [Section] if it doesn't exist and return a mutable
+    /// reference to it.
+    pub(crate) fn insert_profile(
+        &mut self,
+        profile_name: SectionName,
+    ) -> &mut Section<CredentialHeader> {
+        if !self.contains_profile(&profile_name) {
+            let new_profile: Section<CredentialHeader> =
+                Section::new(CredentialHeader::new(profile_name.clone()));
+            self.profiles.push(new_profile);
+        }
+
+        #[allow(clippy::unwrap_used)]
+        // This cannot fail because we just added the item if it didn't exist
+        self.get_profile_mut(profile_name).unwrap()
+    }
+}
+
+impl Display for AwsCredentialsFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{}{}",
+            self.leading_whitespace,
+            self.profiles
+                .iter()
+                .map(Section::to_string)
+                .collect::<String>(),
+            self.trailing_whitespace
+        )
     }
 }
 

--- a/src/model/header.rs
+++ b/src/model/header.rs
@@ -140,7 +140,7 @@ impl CredentialHeader {
 
 impl Display for CredentialHeader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[{}]", self.profile_name)
+        write!(f, "[{}]{}", self.profile_name, self.whitespace)
     }
 }
 

--- a/src/model/nested_settings.rs
+++ b/src/model/nested_settings.rs
@@ -5,9 +5,9 @@ use crate::lexer::Parsable;
 use nom::{combinator::map, multi::many0, Parser};
 use std::{fmt::Display, ops::Deref};
 
-/// Given the configuration file excert below:
+/// Given the configuration file excerpt below:
 ///
-/// ```
+/// ```ignore
 /// [profile test]
 /// region = us-west-2
 /// s3 =

--- a/src/model/section.rs
+++ b/src/model/section.rs
@@ -37,6 +37,7 @@ where
     pub fn new(header: T) -> Self {
         Self {
             header,
+            trailing_whitespace: Whitespace::newline(),
             ..Default::default()
         }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -302,16 +302,23 @@ aws_access_key_id=AKIAIOSFODNN7EXAMPLE
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZVERYLONGSTRINGEXAMPLE
 [extra]
-aws_access_key_id = hi"#;
+aws_access_key_id = hi
+[another]
+aws_access_key_id = hi
+"#;
 
     let mut config = SAMPLE_CRED_FILE
         .parse::<AwsCredentialsFile>()
         .expect("Should be valid");
 
-    let profile = config
+    let extra_profile = config
         .insert_profile("extra".parse().expect("Should be valid"));
-    profile.set("aws_access_key_id".parse().expect("Should be valid"), Value::from("hi"));
+    extra_profile.set("aws_access_key_id".parse().expect("Should be valid"), Value::from("hi"));
+    let another_profile = config
+        .insert_profile("another".parse().expect("Should be valid"));
+    another_profile.set("aws_access_key_id".parse().expect("Should be valid"), Value::from("hi"));
 
+    // Write the content back to your file
     let stringified = config.to_string();
     assert_eq!(stringified, EXPECTED)
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -280,11 +280,10 @@ aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3
         .parse::<AwsCredentialsFile>()
         .expect("Should be valid");
 
-    config.set(
-        SettingPath::try_from("profile.default.aws_access_key_id")
-            .expect("Should parse"),
-        Value::from("hi"),
-    );
+    let profile = config
+        .get_profile_mut("default".parse().expect("Should be valid"))
+        .expect("Should have found the default profile");
+    profile.set_value(&"aws_access_key_id".parse().expect("Should be valid"), ValueType::Single(Value::from("hi")));
 
     let stringified = config.to_string();
     assert_eq!(stringified, EXPECTED)
@@ -309,11 +308,9 @@ aws_access_key_id = hi"#;
         .parse::<AwsCredentialsFile>()
         .expect("Should be valid");
 
-    config.set(
-        SettingPath::try_from("profile.extra.aws_access_key_id")
-            .expect("Should parse"),
-        Value::from("hi"),
-    );
+    let profile = config
+        .insert_profile("extra".parse().expect("Should be valid"));
+    profile.set("aws_access_key_id".parse().expect("Should be valid"), Value::from("hi"));
 
     let stringified = config.to_string();
     assert_eq!(stringified, EXPECTED)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -261,3 +261,60 @@ fn update_a_credential_file() {
 
     assert_eq!(*setting, ValueType::Single(Value::from("hi")))
 }
+
+#[test]
+fn update_settings_in_a_credential_file() {
+    const EXPECTED: &str = r#"
+[default]
+aws_access_key_id=hi
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZVERYLONGSTRINGEXAMPLE
+
+[other]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZVERYLONGSTRINGEXAMPLE
+"#;
+
+    let mut config = SAMPLE_CRED_FILE
+        .parse::<AwsCredentialsFile>()
+        .expect("Should be valid");
+
+    config.set(
+        SettingPath::try_from("profile.default.aws_access_key_id")
+            .expect("Should parse"),
+        Value::from("hi"),
+    );
+
+    let stringified = config.to_string();
+    assert_eq!(stringified, EXPECTED)
+}
+
+#[test]
+fn add_settings_in_a_credential_file() {
+    const EXPECTED: &str = r#"
+[default]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZVERYLONGSTRINGEXAMPLE
+
+[other]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZVERYLONGSTRINGEXAMPLE
+[extra]
+aws_access_key_id = hi"#;
+
+    let mut config = SAMPLE_CRED_FILE
+        .parse::<AwsCredentialsFile>()
+        .expect("Should be valid");
+
+    config.set(
+        SettingPath::try_from("profile.extra.aws_access_key_id")
+            .expect("Should parse"),
+        Value::from("hi"),
+    );
+
+    let stringified = config.to_string();
+    assert_eq!(stringified, EXPECTED)
+}


### PR DESCRIPTION
fixes #1 
also addresses a serialization bug where whitespace was missing after a credential header